### PR TITLE
lite version without vbox

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -15,6 +15,7 @@ ARG GIT_REVISION
 ARG VBOX_VERSION_WIN
 ARG VBOX_REV_WIN
 ARG MIXPANEL_TOKEN
+ARG VARIANT
 
 RUN dpkg --add-architecture i386
 RUN sed -i "s/main/main contrib non-free/" /etc/apt/sources.list.d/debian.sources
@@ -92,18 +93,30 @@ RUN if [ $GIT_REVISION -gt 1 ]; then GIT_FILENAME="Git-$GIT_VERSION.$GIT_REVISIO
 ENV VBOX_URL "https://download.virtualbox.org/virtualbox/$VBOX_VERSION_WIN"
 ENV VBOX_EXE "$VBOX_URL/VirtualBox-$VBOX_VERSION_WIN-$VBOX_REV_WIN-Win.exe"
 
-RUN curl -fsSL -o virtualbox.exe "$VBOX_EXE" \
-	&& echo "$(curl -fsSL "$VBOX_URL"'/SHA256SUMS' \
-	| awk '$2 ~ /-Win.exe$/ { print $1 }') *virtualbox.exe" \
-	| sha256sum -c -
+RUN if [ "$VARIANT" != "-lite" ]; then \
+		curl -fsSL -o virtualbox.exe "$VBOX_EXE" \
+		&& echo "$(curl -fsSL "$VBOX_URL"'/SHA256SUMS' \
+		| awk '$2 ~ /-Win.exe$/ { print $1 }') *virtualbox.exe" \
+		| sha256sum -c -; \
+	fi
 
-RUN wine virtualbox.exe -extract -silent -path . && \
-	  rm virtualbox.exe && \
-	  mv *.msi VirtualBox_amd64.msi
+RUN if [ "$VARIANT" != "-lite" ]; then \
+		wine virtualbox.exe -extract -silent -path . && \
+		rm virtualbox.exe && \
+		mv *.msi VirtualBox_amd64.msi; \
+	fi
 
 # Add installer resources
 COPY windows /installer
 
 WORKDIR /installer
 RUN rm -rf /tmp/.wine-0/
-RUN wine ../innosetup/ISCC.exe Toolbox.iss /DMyAppVersion=$INSTALLER_VERSION /DMixpanelToken=$MIXPANEL_TOKEN
+RUN if [ "$VARIANT" = "-lite" ]; then \
+		sed -i 's|^#define MyAppName "Toolbox2docker"|#define MyAppName "Toolbox2docker'$VARIANT'"|g' Toolbox.iss; \
+		sed -i 's|^AppId=.*$|AppId={{5DFD8320-1E10-11EF-9E35-0800200C9A66}|g' Toolbox.iss; \
+		sed -i 's|^Name: vbox_ndis5;|// Name: vbox_ndis5;|g' Toolbox.iss; \
+		sed -i 's|^Name: "VirtualBox";|// Name: "VirtualBox";|g' Toolbox.iss; \
+		sed -i 's|^Source: "{#virtualBoxMsi}"|// Source: "{#virtualBoxMsi}"|g' Toolbox.iss; \
+		sed -i 's|Wizardform\.ComponentsList\.|// Wizardform\.ComponentsList\.|g' Toolbox.iss; \
+	fi && \
+	wine ../innosetup/ISCC.exe Toolbox.iss /DMyAppVersion=$INSTALLER_VERSION /DMixpanelToken=$MIXPANEL_TOKEN

--- a/README.md
+++ b/README.md
@@ -129,4 +129,6 @@ The resulting installers will be in the `dist` directory.
 
 **Do I have to install VirtualBox?**
 
-No, you can deselect VirtualBox during installation. It is bundled in case you want to have a working environment for free.
+No, there is a lite version that comes without VirtualBox.
+
+You can also deselect VirtualBox during installation in the default installer. It is bundled in case you want to have a working environment for free.

--- a/script/build-windows
+++ b/script/build-windows
@@ -3,25 +3,32 @@
 set -e
 
 . versions
-docker build \
-	-t windows-installer \
-	-f Dockerfile.windows \
-	--build-arg DOCKER_RELEASE_STAGE="${DOCKER_RELEASE_STAGE}" \
-	--build-arg INSTALLER_VERSION="${INSTALLER_VERSION}" \
-	--build-arg DOCKER_VERSION="${DOCKER_VERSION}" \
-	--build-arg DOCKER_BUILDX_VERSION="${DOCKER_BUILDX_VERSION}" \
-	--build-arg DOCKER_COMPOSE2_VERSION="${DOCKER_COMPOSE2_VERSION}" \
-	--build-arg DOCKER_MACHINE_VERSION="${DOCKER_MACHINE_VERSION}" \
-	--build-arg GITLAB_MACHINE_VERSION="${GITLAB_MACHINE_VERSION}" \
-	--build-arg T2D_MACHINE_VERSION="${T2D_MACHINE_VERSION}" \
-	--build-arg GIT_VERSION="${GIT_VERSION}" \
-	--build-arg GIT_REVISION="${GIT_REVISION}" \
-	--build-arg VBOX_VERSION_WIN="${VBOX_VERSION_WIN}" \
-	--build-arg VBOX_REV_WIN="${VBOX_REV_WIN}" \
-	--build-arg MIXPANEL_TOKEN="${MIXPANEL_TOKEN}" \
-	.
-CONTAINER="$(docker create windows-installer)"
-mkdir -p dist
-docker cp "${CONTAINER}":/installer/Output/Toolbox2docker.exe \
-		dist/Toolbox2docker-${INSTALLER_VERSION}.exe
-docker rm "${CONTAINER}" 2>/dev/null || true
+
+declare -a variants=("-lite" "")
+
+for variant in "${variants[@]}"
+do
+	docker build \
+		-t windows-installer"${variant}" \
+		-f Dockerfile.windows \
+		--build-arg VARIANT="${variant}" \
+		--build-arg DOCKER_RELEASE_STAGE="${DOCKER_RELEASE_STAGE}" \
+		--build-arg INSTALLER_VERSION="${INSTALLER_VERSION}" \
+		--build-arg DOCKER_VERSION="${DOCKER_VERSION}" \
+		--build-arg DOCKER_BUILDX_VERSION="${DOCKER_BUILDX_VERSION}" \
+		--build-arg DOCKER_COMPOSE2_VERSION="${DOCKER_COMPOSE2_VERSION}" \
+		--build-arg DOCKER_MACHINE_VERSION="${DOCKER_MACHINE_VERSION}" \
+		--build-arg GITLAB_MACHINE_VERSION="${GITLAB_MACHINE_VERSION}" \
+		--build-arg T2D_MACHINE_VERSION="${T2D_MACHINE_VERSION}" \
+		--build-arg GIT_VERSION="${GIT_VERSION}" \
+		--build-arg GIT_REVISION="${GIT_REVISION}" \
+		--build-arg VBOX_VERSION_WIN="${VBOX_VERSION_WIN}" \
+		--build-arg VBOX_REV_WIN="${VBOX_REV_WIN}" \
+		--build-arg MIXPANEL_TOKEN="${MIXPANEL_TOKEN}" \
+		.
+	CONTAINER="$(docker create windows-installer${variant})"
+	mkdir -p dist
+	docker cp "${CONTAINER}":/installer/Output/Toolbox2docker.exe \
+			dist/Toolbox2docker${variant}-${INSTALLER_VERSION}.exe
+	docker rm "${CONTAINER}" 2>/dev/null || true
+done


### PR DESCRIPTION
PoC for Lite version

- we create two files now
- I suggest having separate names e.g. "Toolbox2docker" and "Toolbox2docker-lite" (this is reflected in the installed Apps on windows)
- We have to change the AppId to a new Random Guid (as Toolbox2docker-lite creates a new directory and this can cause issues when - stupid - users installs the full on an existing lite version and the way around)
- For security reasons - you as maintainer - please create a random guid (in the Docker.windows file) and don't use "my magic string from a random dude" of the internet is not trustworthy
- `AppId={{FC4417F0-D7F3-48DB-BCE1-F5ED5BAFFD91}` looked somehow odd - as it has only one closing bracket - but it's correct <https://stackoverflow.com/posts/61174457/revisions> (please double check - I am no expert).

Ping me if I need to add changes.
